### PR TITLE
Fix(buildversion): updating correctly with 'dotnet pack' command.

### DIFF
--- a/Samples/SampleApp.Tests/Properties/AssemblyInfo.cs
+++ b/Samples/SampleApp.Tests/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SampleApp.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/Samples/SampleApp/Properties/AssemblyInfo.cs
+++ b/Samples/SampleApp/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SampleApp")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/TestAssembly/Properties/AssemblyInfo.cs
+++ b/TestAssembly/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("TestAssembly")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/TestStack.ConventionTests.Autofac/Properties/AssemblyInfo.cs
+++ b/TestStack.ConventionTests.Autofac/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("TestStack.ConventionTests.Autofac")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/TestStack.ConventionTests.Tests/Properties/AssemblyInfo.cs
+++ b/TestStack.ConventionTests.Tests/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using TestStack.ConventionTests.Reporting;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("TestStack.ConventionTests.Tests")]
-[assembly: AssemblyCopyright("Copyright © TestStack 2013")]
+[assembly: AssemblyCopyright("Copyright © TestStack 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/TestStack.ConventionTests/Properties/AssemblyInfo.cs
+++ b/TestStack.ConventionTests/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("TestStack.ConventionTests")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright © 2020")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,8 @@ build:
   project: ConventionTests.sln
 
 after_build:
-  - cmd: dotnet pack TestStack.ConventionTests\TestStack.ConventionTests.csproj -c Release -o .\artifacts --include-symbols -v n
-  - cmd: dotnet pack TestStack.ConventionTests.Autofac\TestStack.ConventionTests.Autofac.csproj -c Release -o .\artifacts --include-symbols -v n
+  - cmd: dotnet pack TestStack.ConventionTests\TestStack.ConventionTests.csproj -c Release -o .\artifacts -p:PackageVersion="%GitVersion_NuGetVersion%" --include-symbols -v n
+  - cmd: dotnet pack TestStack.ConventionTests.Autofac\TestStack.ConventionTests.Autofac.csproj -c Release -o .\artifacts -p:PackageVersion="%GitVersion_NuGetVersion%" --include-symbols -v n
 
 artifacts:
   - path: '.\artifacts\*.nupkg'


### PR DESCRIPTION
Appveyor config fixed to publish correct GitVersion label.  The previous PR it was always 1.0.0
Prior only updated AssemblyInfo which appears ignored for don't pack 
chore: Update Copyright to 2020.